### PR TITLE
Fix raising IndexError in type.py

### DIFF
--- a/plugins/type.py
+++ b/plugins/type.py
@@ -31,7 +31,7 @@ async def type(client: Client, message: Message):
     tbp = ""
     typing_symbol = "▒"
 
-    while tbp != text:
+    while text: # while the text string is not empty
         try:
             await message.edit(tbp + typing_symbol)
             await asyncio.sleep(0.1)


### PR DESCRIPTION
Currently, the type plugin raises IndexError every time it's called and it does not remove the last cursor symbol. This patch fixes it