### PR TITLE
Disabled antipm for support accounts

### DIFF
--- a/modules/antipm.py
+++ b/modules/antipm.py
@@ -27,9 +27,11 @@ anti_pm_enabled = filters.create(
 
 in_contact_list = filters.create(lambda _, __, message: message.from_user.is_contact)
 
+is_support = filters.create(lambda _, __, message: message.chat.is_support)
+
 
 @Client.on_message(
-    filters.private & ~filters.me & ~filters.bot & ~in_contact_list & anti_pm_enabled
+    filters.private & ~filters.me & ~filters.bot & ~in_contact_list & ~is_support & anti_pm_enabled
 )
 async def anti_pm_handler(client: Client, message: Message):
     await client.read_history(message.chat.id)


### PR DESCRIPTION
Disabled PM from support accounts because usually they send useful info, but it can't be added to contact list (at least from official telegram clients)