### PR TITLE
Security problem : `sudo pip install` is a broken practice

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,8 +12,8 @@ fi
 apt update -y
 apt install python3 python3-pip git ffmpeg wget gnupg -y || exit 2
 
-su -c "python3 -m pip install -U pip" $SUDO_USER
-su -c "python3 -m pip install -U wheel pillow" $SUDO_USER
+python3 -m pip install -U pip
+python3 -m pip install -U wheel pillow
 
 if [[ -d "Dragon-Userbot" ]]; then
   cd Dragon-Userbot
@@ -29,7 +29,7 @@ if [[ -f ".env" ]] && [[ -f "my_account.session" ]]; then
   exit
 fi
 
-su -c "python3 -m pip install -U -r requirements.txt" $SUDO_USER || exit 2
+python3 -m pip install -U -r requirements.txt || exit 2
 
 echo
 echo "Enter API_ID and API_HASH"


### PR DESCRIPTION
Both sudo pip install and its other common variant sudo -H pip install should not be encouraged because it is a security risk to use root privileges to use pip to install Python packages from PyPI (Python Package Index).

From https://stackoverflow.com/a/21056000/486919 (emphasis mine):

> When you run pip with sudo, you run setup.py with sudo. In other words, you run arbitrary Python code from the Internet as root. If someone puts up a malicious project on PyPI and you install it, you give an attacker root access to your machine. Prior to some recent fixes to pip and PyPI, an attacker could also run a man in the middle attack to inject their code when you download a trustworthy project.

As mentioned at https://security.stackexchange.com/a/79327/8761, it is important to note that anyone can upload Python packages, including malicious ones, to PyPI.